### PR TITLE
Fix missing support for cc and bcc recipients

### DIFF
--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -50,31 +50,19 @@ class MandrillTransport extends AbstractTransport
 
             if (!empty($original_message->getTo())) {
                 foreach ($original_message->getTo() as $to) {
-                    $recipients[] = [
-                        'email' => $to->getEncodedAddress(),
-                        'name' => $to->getEncodedName(),
-                        'type' => 'to',
-                    ];
+                    $recipients[] = $to->getEncodedAddress();
                 }
             }
 
             if (!empty($original_message->getCc())) {
                 foreach ($original_message->getCc() as $cc) {
-                    $recipients[] = [
-                        'email' => $cc->getEncodedAddress(),
-                        'name' => $cc->getEncodedName(),
-                        'type' => 'cc',
-                    ];
+                    $recipients[] = $cc->getEncodedAddress();
                 }
             }
 
             if (!empty($original_message->getBcc())) {
                 foreach ($original_message->getBcc() as $bcc) {
-                    $recipients[] = [
-                        'email' => $bcc->getEncodedAddress(),
-                        'name' => $bcc->getEncodedName(),
-                        'type' => 'bcc',
-                    ];
+                    $recipients[] = $bcc->getEncodedAddress();
                 }
             }
         }
@@ -82,7 +70,7 @@ class MandrillTransport extends AbstractTransport
         // Fall-back to envelope recipients
         if (empty($recipients)) {
             foreach ($message->getEnvelope()->getRecipients() as $recipient) {
-                $recipients[] = $recipient->getAddress();
+                $recipients[] = $recipient->getEncodedAddress();
             }
         }
 

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -16,6 +16,7 @@ class MandrillTransport extends AbstractTransport
      */
     public function __construct(protected ApiClient $mailchimp, protected array $headers)
     {
+        parent::__construct();
     }
 
     /**

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -29,7 +29,19 @@ class MandrillTransport extends AbstractTransport
         $this->mailchimp->messages->sendRaw([
             'raw_message' => $message->toString(),
             'async' => true,
+            'to' => $this->getTo($message),
         ]);
+    }
+
+    protected function getTo(SentMessage $message): array
+    {
+        $to = [];
+
+        foreach ($message->getEnvelope()->getRecipients() as $recipient) {
+            $to[] = $recipient->getAddress();
+        }
+
+        return $to;
     }
 
     /**


### PR DESCRIPTION
This PR solves issue #29 and adds support for the cc and bcc recipients that were previously present prior to v4.0.0. It checks the type of the original message and, in case of it being of the type `Symfony\Component\Mime\Email`, it will use the existing methods in that class to retrieve the `to`, `cc` and `bcc` recipients.

Note that the behaviour of this added functionality is similar to v3.x.x, meaning that all the recipients are considered as `to` recipients on the Mandrill side. Each recipient will receive an individual mail message, rather than sending a group message with the `to`, `cc` and `bcc` fields populated.

Because I couldn't get the package running due to issue #32, I have forked this from PR #33. It means that this PR also contains the fix for issue #32 provided by @radykal-com.