### PR TITLE
Add GitHub CI + Update readme with information on accessing Mandrill Message Id's

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,13 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Composer dependencies
+      run: composer install
+    - name: Execute tests
+      run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
-phpunit.xml
 .idea

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.4",
         "phpunit/phpunit": "^9.5.10",
-        "orchestra/testbench": "^v7.24"
+        "orchestra/testbench": "^v8.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="Laravel Mandrill Driver Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ You can also add custom Mandrill headers to each email sent, for this you need t
 all the valid options in Mandrill docs at: https://mailchimp.com/developer/transactional/docs/smtp-integration/#customize-messages-with-smtp-headers
 
 
-### Accessing Mandrill message ID
+#### Accessing Mandrill message ID
 Mandrill message ID's for sent emails can be accessed by listening to the `MessageSent` event. It can then be read either from the sent data or the X-Message-ID header.
 
 ```php

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,20 @@ You can also add custom Mandrill headers to each email sent, for this you need t
 ```
 all the valid options in Mandrill docs at: https://mailchimp.com/developer/transactional/docs/smtp-integration/#customize-messages-with-smtp-headers
 
+
+### Accessing Mandrill message ID
+Mandrill message ID's for sent emails can be accessed by listening to the `MessageSent` event. It can then be read either from the sent data or the X-Message-ID header.
+
+```php
+
+Event::listen(\Illuminate\Mail\Events\MessageSent::class, function($event)
+{
+    $messageId = $event->sent->getMessageId();
+    $messageId = $event->message->getHeaders()->get('X-Message-ID');
+}
+ 
+```
+
 ## Versions
 
 | Laravel Version  | Mandrill package version         |

--- a/tests/MandrillTransportTest.php
+++ b/tests/MandrillTransportTest.php
@@ -14,7 +14,7 @@ use MailchimpTransactional\ApiClient;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Mail\Events\MessageSent;
 
-class MailerSendTransportTest extends TestCase
+class MandrillTransportTest extends TestCase
 {
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
Hi @luisdalmolin, please let me know if there is anything you would like me to tweak/change in this PR.

Key changes;

**1) Add config for GitHub CI**
It took me a few attempts to realise the `.gitignore` meant I hadn't pushed my phpunit up 😄 
* Updates `orchestra/testbench` to L10 compatible branch.
* Add `phpunit.xml` config & github CI workflow config.
* Fix naming of the unit test to match file name

**2) Update readme**
This is pretty much just me adding a section re: how to access the MessageId details from the sentMessage event. Let me know if there's anything i can improve on the description. 

With luck the github ci config should apply to this PR automatically 🤞 
If not, you may need to enable it on the repo (I think on https://github.com/luisdalmolin/laravel-mandrill-driver/settings/actions). You can see an example of what it should look like when running on https://github.com/thybag/laravel-mandrill-driver/pull/2

