### PR TITLE
Add proper exception when Mandrill returns an error

### DIFF
--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -47,6 +47,11 @@ class MandrillTransport extends AbstractTransport
             'to' => $this->getTo($message),
         ]);
 
+        if ($data instanceof \GuzzleHttp\Exception\RequestException)
+        {
+            throw new MandrillTransportException($data->getMessage(), $data->getCode(), $data);
+        }
+
         // If Mandrill _id was returned, set it as the message id for
         // use elsewhere in the application.
         if (!empty($data[0]?->_id)) {

--- a/src/MandrillTransportException.php
+++ b/src/MandrillTransportException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaravelMandrill;
+
+use Symfony\Component\Mailer\Exception\TransportException;
+
+class MandrillTransportException extends TransportException
+{
+    //
+}


### PR DESCRIPTION
Mandrill sometimes returns 500 errors, which caused errors like "Cannot use object of type GuzzleHttp\Exception\ServerException as array" because of: 
https://github.com/luisdalmolin/laravel-mandrill-driver/blob/e10efc6613a251a5fc423b4bad79ae70aa558667/src/MandrillTransport.php#L52 

This change adds a proper exception that can be caught.