### PR TITLE
Update Requirements + Fix Implicit Nullable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "illuminate/support": "^11.0",
         "mailchimp/transactional": "^1.0",
         "symfony/mailer": "^7.0"

--- a/src/MandrillTransport.php
+++ b/src/MandrillTransport.php
@@ -27,7 +27,7 @@ class MandrillTransport extends AbstractTransport
     /**
      * {@inheritDoc}
      */
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         // Set headers must take place before SentMessage is formed or it will not be part
         // of the payload submitted to the Mandrill API.


### PR DESCRIPTION
I updated the requirements to `"php": "^8.2"` because it is required by `illuminate/support`, when I ran `composer install` using 8.1 I got this error:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires illuminate/support ^11.0 -> satisfiable by illuminate/support[v11.0.0, ..., v11.43.2], laravel/framework[v11.0.0, ..., v11.43.2].
    - illuminate/support[v11.0.0, ..., v11.43.2] require php ^8.2 -> your php version (8.1.31) does not satisfy that requirement.
    - laravel/framework[v11.0.0, ..., v11.43.2] require php ^8.2 -> your php version (8.1.31) does not satisfy that requirement.
 ```
 
I'm running PHP 8.4 in production and noticed a deprecation message popping up in the logs, `LaravelMandrill\MandrillTransport::send(): Implicitly marking parameter $envelope as nullable is deprecated, the explicit nullable type must be used instead`.  The other change was to explicitly mark that parameter as nullable instead of leaving it implicit.